### PR TITLE
 "Add patch for Moyo, RedMoyo, Moyo Cartel and Paniel"

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -2,6 +2,7 @@
 <loadFolders>
     <v1.4>
         <li>/</li>
+        <li>1.4</li>
         <li IfModActive="nemonian.my">harRacesEvaPatches/Moyo</li>
         <li IfModActive="roo.antyracemod">harRacesEvaPatches/Anty</li>
         <li IfModActive="ahndemi.panieltheautomata">harRacesEvaPatches/Paniel</li>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<loadFolders>
+    <v1.4>
+        <li>/</li>
+        <li IfModActive="nemonian.my">harRacesEvaPatches/Moyo</li>
+        <li IfModActive="roo.antyracemod">harRacesEvaPatches/Anty</li>
+        <li IfModActive="ahndemi.panieltheautomata">harRacesEvaPatches/Paniel</li>
+        <li IfModActive="aoba.redmoyo">harRacesEvaPatches/RedMoyo</li>
+        <li IfModActive="nemonian.mycartel">harRacesEvaPatches/MoyoCartel</li>
+    </v1.4>
+</loadFolders>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -2,7 +2,6 @@
 <loadFolders>
     <v1.4>
         <li>/</li>
-        <li>1.4</li>
         <li IfModActive="nemonian.my">harRacesEvaPatches/Moyo</li>
         <li IfModActive="roo.antyracemod">harRacesEvaPatches/Anty</li>
         <li IfModActive="ahndemi.panieltheautomata">harRacesEvaPatches/Paniel</li>

--- a/harRacesEvaPatches/Moyo/Patches/MoyoEvaPatch.xml
+++ b/harRacesEvaPatches/Moyo/Patches/MoyoEvaPatch.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <!-- DIVING SUIT PATCH -->
+    <Operation Class="PatchOperationConditional">
+        <xpath>Defs/ThingDef[defName="Moyo_LDgear" or defName="Moyo_LDhelmet"]/apparel/tags</xpath>
+        <nomatch Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="Moyo_LDgear" or defName="Moyo_LDhelmet"]/apparel</xpath>
+            <value>
+                <tags />
+            </value>
+        </nomatch>
+    </Operation>
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="Moyo_LDgear" or defName="Moyo_LDhelmet"]/apparel/tags</xpath>
+        <value>
+            <li>EVA</li>
+        </value>
+    </Operation>
+
+    <!-- DEEP DIVING SUIT PATCH -->
+    <Operation Class="PatchOperationConditional">
+        <xpath>Defs/ThingDef[defName="Moyo_DDgear" or defName="Moyo_DDhelmet"]/apparel/tags</xpath>
+        <nomatch Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="Moyo_DDgear" or defName="Moyo_DDhelmet"]/apparel</xpath>
+            <value>
+                <tags />
+            </value>
+        </nomatch>
+    </Operation>
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="Moyo_DDgear" or defName="Moyo_DDhelmet"]/apparel/tags</xpath>
+        <value>
+            <li>EVA</li>
+        </value>
+    </Operation>
+
+    <!-- ROYALGUARD LIGHT ARMOR PATCH -->
+    <Operation Class="PatchOperationConditional">
+        <xpath>Defs/ThingDef[defName="Moyo_GSsuit" or defName="Moyo_GShelmet"]/apparel/tags</xpath>
+        <nomatch Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="Moyo_GSsuit" or defName="Moyo_GShelmet"]/apparel</xpath>
+            <value>
+                <tags />
+            </value>
+        </nomatch>
+    </Operation>
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="Moyo_GSsuit" or defName="Moyo_GShelmet"]/apparel/tags</xpath>
+        <value>
+            <li>EVA</li>
+        </value>
+    </Operation>
+
+    <!-- ROYALGUARD ARMOR PATCH -->
+    <Operation Class="PatchOperationConditional">
+        <xpath>Defs/ThingDef[defName="Moyo_GDsuit" or defName="Moyo_GDhelmet"]/apparel/tags</xpath>
+        <nomatch Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="Moyo_GDsuit" or defName="Moyo_GDhelmet"]/apparel</xpath>
+            <value>
+                <tags />
+            </value>
+        </nomatch>
+    </Operation>
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="Moyo_GDsuit" or defName="Moyo_GDhelmet"]/apparel/tags</xpath>
+        <value>
+            <li>EVA</li>
+        </value>
+    </Operation>
+</Patch>

--- a/harRacesEvaPatches/MoyoCartel/Patches/CartelEvaPatch.xml
+++ b/harRacesEvaPatches/MoyoCartel/Patches/CartelEvaPatch.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+        <!-- CARTEL EXECUTIONER GEAR PATCH -->
+        <Operation Class="PatchOperationConditional">
+            <xpath>Defs/ThingDef[defName="Moyo_CEsuit" or defName="Moyo_CEhelmet"]/apparel/tags</xpath>
+            <nomatch Class="PatchOperationAdd">
+                <xpath>Defs/ThingDef[defName="Moyo_CEsuit" or defName="Moyo_CEhelmet"]/apparel</xpath>
+                <value>
+                    <tags />
+                </value>
+            </nomatch>
+        </Operation>
+        <Operation Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="Moyo_CEsuit" or defName="Moyo_CEhelmet"]/apparel/tags</xpath>
+            <value>
+                <li>EVA</li>
+            </value>
+        </Operation>
+
+        <!-- CARTEL STRIKER GEAR PATCH -->
+        <Operation Class="PatchOperationConditional">
+            <xpath>Defs/ThingDef[defName="Moyo_CSgear" or defName="Moyo_CShelmet"]/apparel/tags</xpath>
+            <nomatch Class="PatchOperationAdd">
+                <xpath>Defs/ThingDef[defName="Moyo_CSgear" or defName="Moyo_CShelmet"]/apparel</xpath>
+                <value>
+                    <tags />
+                </value>
+            </nomatch>
+        </Operation>
+        <Operation Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="Moyo_CSgear" or defName="Moyo_CShelmet"]/apparel/tags</xpath>
+            <value>
+                <li>EVA</li>
+            </value>
+        </Operation>
+</Patch>

--- a/harRacesEvaPatches/Paniel/Patches/PanielEvaPatch.xml
+++ b/harRacesEvaPatches/Paniel/Patches/PanielEvaPatch.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <!-- PANIEL RACE PATCH -->
+    <Operation Class="PatchOperationConditional">
+        <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]/tradeTags</xpath>
+        <nomatch Class="PatchOperationAdd">
+            <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]</xpath>
+            <value>
+                <tradeTags />
+            </value>
+        </nomatch>
+    </Operation>
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]/tradeTags</xpath>
+        <value>
+            <li>AnimalInsectSpace</li>
+        </value>
+    </Operation>
+</Patch>

--- a/harRacesEvaPatches/RedMoyo/Patches/RedMoyoEvaPatch.xml
+++ b/harRacesEvaPatches/RedMoyo/Patches/RedMoyoEvaPatch.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <!-- ABYSS ARMOUR PATCH -->
+    <Operation Class="PatchOperationConditional">
+        <xpath>Defs/ThingDef[defName="RedMoyo_AbyssArmour" or defName="RedMoyo_AbyssHelmet"]/apparel/tags</xpath>
+        <nomatch Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="RedMoyo_AbyssArmour" or defName="RedMoyo_AbyssHelmet"]/apparel</xpath>
+            <value>
+                <tags />
+            </value>
+        </nomatch>
+    </Operation>
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="RedMoyo_AbyssArmour" or defName="RedMoyo_AbyssHelmet"]/apparel/tags</xpath>
+        <value>
+            <li>EVA</li>
+        </value>
+    </Operation>
+</Patch>


### PR DESCRIPTION
Added a loadFolders.xml, to more easily check and enable the patches only if said mod is present.
All patches are inside the harRacesEvaPatches folder.
For the Moyo, RedMoyo and Cartel, the armors that covers the whole body (their counterpart to powerarmors) have been given the EVA tag.
For the Mincho and Anty, races we've talked in discord, those 2 have the patches added in their own XMLs.
For Paniel, I added the AnimalInsectSpace tradeTag to them, making the whole race immune to vacuum without taking into account what they are wearing. (The paniel did have the EVA tag in a series of patches detecting if SoS2 was active, but they were just patching over all the clothes the mod has, using a <Success>Always</Success>, so I didn't want to just copy and paste that patch, or patch every individual apparel, either.)
also ignore the 2 commits that add and remove a 1.4 on the loadfolders, i though you had a 1.4 folder in your mod, but you apparently don't.